### PR TITLE
Suppress warning for 

### DIFF
--- a/Sources/FastCGIServer.swift
+++ b/Sources/FastCGIServer.swift
@@ -78,7 +78,7 @@ public class FastCGIServer {
 	
 	/// Add the Routes to this server.
 	public func addRoutes(_ routes: Routes) {
-		self.routes.add(routes: routes)
+		self.routes.add(routes)
 	}
 
 	/// Start the server on the indicated named pipe


### PR DESCRIPTION
I'm getting this warning while building PerfectFastCGI Template

`'add(routes:)' is deprecated: Use Routes.add(_:Routes)`

changing the `FastCGIServer.swift` should solve it. Please check.