### PR TITLE
Fixed conforming of FastCGIRequest to protocol HTTPRequest

### DIFF
--- a/Sources/FastCGIRequest.swift
+++ b/Sources/FastCGIRequest.swift
@@ -28,6 +28,7 @@ final class FastCGIRequest: HTTPRequest {
     
     var method = HTTPMethod.get
     var path = ""
+	var pathComponents = [String]()
     var queryString = ""
     var protocolVersion = (1, 0)
     var remoteAddress = (host: "", port: 0 as UInt16)


### PR DESCRIPTION
A 'pathComponents' field of type [String] was added to HTTPRequest. Previously,
building Perfect-FastCGI would exit with error code 1 due to non conformity.
This fix merely satisfies the protocol implementation, without modifying the
logic of the request object.