### PR TITLE
Bugfix that self.net of TCP port server is always nil.

### DIFF
--- a/Sources/FastCGIServer.swift
+++ b/Sources/FastCGIServer.swift
@@ -105,6 +105,7 @@ public class FastCGIServer {
 		let socket = NetTCP()
 		try socket.bind(port: prt, address: bindAddress)
 		socket.listen()
+		self.net = socket
 		defer { socket.close() }
 		print("Starting FastCGi server on \(bindAddress):\(prt)")
 		self.start()


### PR DESCRIPTION
Hello,

I found FastCGIServer.start(port prt: UInt16, bindAddress: String) does not work because it does not set self.net.